### PR TITLE
GH: Adds long description to Jekyll theme (YML)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 title: mobinfo
 tagline: A command-line tool that offers mobile phone information.
-description: A command-line tool that offers mobile phone information ⚡
+description: A command-line tool written in Bash 4.2+ that offers comprehensive and up-to-date mobile phone information from various online websites.
 url: https://grm34.github.io/mobinfo
 author:
   name: darkmaster @grm34


### PR DESCRIPTION
Replaces the tagline that was used as website description by the long description in the Jekyll theme config file.

Signed-off-by: grm34 <jerem.pardo@tutanota.com>